### PR TITLE
Update Cargo.toml

### DIFF
--- a/savefile/Cargo.toml
+++ b/savefile/Cargo.toml
@@ -45,7 +45,7 @@ indexmap = { version = "1.6", optional = true}
 parking_lot = { version = "0.12", optional = true }
 ring = {version = "0.16.9", optional = true}
 rand = { version = "0.8", optional = true}
-bzip2 = {version = "0.4", optional = true}
+bzip2 = {version = "0.4.4", optional = true}
 bit-set = {version = "0.5", optional = true}
 rustc-hash = {version = "1.1", optional = true}
 


### PR DESCRIPTION
Updates bzip dependency to the patch version of 0.4.4

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0004.html)
[fix](https://github.com/alexcrichton/bzip2-rs/pull/86)