### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "savefile"
-version = "0.17.0-beta.14"
+version = "0.17.0-beta.15"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-abi"
-version = "0.17.0-beta.14"
+version = "0.17.0-beta.15"
 dependencies = [
  "byteorder",
  "libloading",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-derive"
-version = "0.17.0-beta.14"
+version = "0.17.0-beta.15"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/savefile-abi/CHANGELOG.md
+++ b/savefile-abi/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0-beta.15](https://github.com/avl/savefile/compare/savefile-abi-v0.17.0-beta.14...savefile-abi-v0.17.0-beta.15) - 2024-04-30
+
+### Fixed
+- AbiConnection cache could become corrupt if AbiConnection was used incorrectly
+- Improve documentation
+
 ## [0.17.0-beta.14](https://github.com/avl/savefile/compare/savefile-abi-v0.17.0-beta.13...savefile-abi-v0.17.0-beta.14) - 2024-04-30
 
 ### Other

--- a/savefile-abi/Cargo.toml
+++ b/savefile-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile-abi"
-version = "0.17.0-beta.14"
+version = "0.17.0-beta.15"
 edition = "2021"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 documentation = "https://docs.rs/savefile-abi/"
@@ -16,7 +16,7 @@ keywords = ["dylib", "dlopen", "ffi"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-savefile = { path="../savefile", version = "=0.17.0-beta.14" }
-savefile-derive = { path="../savefile-derive", version = "=0.17.0-beta.14" }
+savefile = { path="../savefile", version = "=0.17.0-beta.15" }
+savefile-derive = { path="../savefile-derive", version = "=0.17.0-beta.15" }
 byteorder = "1.4"
 libloading = "0.8"

--- a/savefile-derive/CHANGELOG.md
+++ b/savefile-derive/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0-beta.15](https://github.com/avl/savefile/compare/savefile-derive-v0.17.0-beta.14...savefile-derive-v0.17.0-beta.15) - 2024-04-30
+
+### Fixed
+- AbiConnection cache could become corrupt if AbiConnection was used incorrectly
+
 ## [0.17.0-beta.14](https://github.com/avl/savefile/compare/savefile-derive-v0.17.0-beta.13...savefile-derive-v0.17.0-beta.14) - 2024-04-30
 
 ### Fixed

--- a/savefile-derive/Cargo.toml
+++ b/savefile-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile-derive"
-version = "0.17.0-beta.14"
+version = "0.17.0-beta.15"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 
 description = "Custom derive macros for savefile crate - simple, convenient, fast, versioned, binary serialization/deserialization library."

--- a/savefile-test/Cargo.toml
+++ b/savefile-test/Cargo.toml
@@ -12,7 +12,7 @@ nightly=["savefile/nightly"]
 
 [dependencies]
 savefile = { path = "../savefile", features = ["size_sanity_checks", "encryption", "compression","bit-set","bit-vec","rustc-hash","serde_derive", "quickcheck"]}
-savefile-derive = { path = "../savefile-derive", version = "=0.17.0-beta.14" }
+savefile-derive = { path = "../savefile-derive", version = "=0.17.0-beta.15" }
 savefile-abi = { path = "../savefile-abi" }
 bit-vec = "0.6"
 arrayvec="0.7"

--- a/savefile/CHANGELOG.md
+++ b/savefile/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0-beta.15](https://github.com/avl/savefile/compare/savefile-v0.17.0-beta.14...savefile-v0.17.0-beta.15) - 2024-04-30
+
+### Added
+- Support for serializing 'str'
+
+### Fixed
+- Fix bug in deserializing old schemas
+
 ## [0.17.0-beta.14](https://github.com/avl/savefile/compare/savefile-v0.17.0-beta.13...savefile-v0.17.0-beta.14) - 2024-04-30
 
 ### Fixed

--- a/savefile/Cargo.toml
+++ b/savefile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile"
-version = "0.17.0-beta.14"
+version = "0.17.0-beta.15"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 documentation = "https://docs.rs/savefile/"
 homepage = "https://github.com/avl/savefile/"
@@ -54,13 +54,13 @@ bit-set = {version = "0.5", optional = true}
 rustc-hash = {version = "1.1", optional = true}
 memoffset = "0.9"
 byteorder = "1.4"
-savefile-derive = {path="../savefile-derive", version = "=0.17.0-beta.14", optional = true }
+savefile-derive = {path="../savefile-derive", version = "=0.17.0-beta.15", optional = true }
 serde_derive = {version= "1.0", optional = true}
 serde = {version= "1.0", optional = true}
 quickcheck = {version= "1.0", optional = true}
 
 [dev-dependencies]
-savefile-derive = { path="../savefile-derive", version = "=0.17.0-beta.14" }
+savefile-derive = { path="../savefile-derive", version = "=0.17.0-beta.15" }
 
 [build-dependencies]
 rustc_version="0.2"


### PR DESCRIPTION
## 🤖 New release
* `savefile`: 0.17.0-beta.14 -> 0.17.0-beta.15
* `savefile-derive`: 0.17.0-beta.14 -> 0.17.0-beta.15
* `savefile-abi`: 0.17.0-beta.14 -> 0.17.0-beta.15

<details><summary><i><b>Changelog</b></i></summary><p>

## `savefile`
<blockquote>

## [0.17.0-beta.15](https://github.com/avl/savefile/compare/savefile-v0.17.0-beta.14...savefile-v0.17.0-beta.15) - 2024-04-30

### Added
- Support for serializing 'str'

### Fixed
- Fix bug in deserializing old schemas
</blockquote>

## `savefile-derive`
<blockquote>

## [0.17.0-beta.15](https://github.com/avl/savefile/compare/savefile-derive-v0.17.0-beta.14...savefile-derive-v0.17.0-beta.15) - 2024-04-30

### Fixed
- AbiConnection cache could become corrupt if AbiConnection was used incorrectly
</blockquote>

## `savefile-abi`
<blockquote>

## [0.17.0-beta.15](https://github.com/avl/savefile/compare/savefile-abi-v0.17.0-beta.14...savefile-abi-v0.17.0-beta.15) - 2024-04-30

### Fixed
- AbiConnection cache could become corrupt if AbiConnection was used incorrectly
- Improve documentation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).