### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "savefile"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-abi"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "byteorder",
  "libloading",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-derive"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/savefile-abi/CHANGELOG.md
+++ b/savefile-abi/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2](https://github.com/avl/savefile/compare/savefile-abi-v0.17.1...savefile-abi-v0.17.2) - 2024-05-05
+
+### Other
+- updated the following local packages: savefile, savefile-derive
+
 ## [0.17.1](https://github.com/avl/savefile/compare/savefile-abi-v0.17.0...savefile-abi-v0.17.1) - 2024-05-01
 
 ### Other

--- a/savefile-abi/Cargo.toml
+++ b/savefile-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile-abi"
-version = "0.17.1"
+version = "0.17.2"
 edition = "2021"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 documentation = "https://docs.rs/savefile-abi/"
@@ -16,7 +16,7 @@ keywords = ["dylib", "dlopen", "ffi"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-savefile = { path="../savefile", version = "=0.17.1" }
-savefile-derive = { path="../savefile-derive", version = "=0.17.1" }
+savefile = { path="../savefile", version = "=0.17.2" }
+savefile-derive = { path="../savefile-derive", version = "=0.17.2" }
 byteorder = "1.4"
 libloading = "0.8"

--- a/savefile-derive/CHANGELOG.md
+++ b/savefile-derive/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2](https://github.com/avl/savefile/compare/savefile-derive-v0.17.1...savefile-derive-v0.17.2) - 2024-05-05
+
+### Other
+- Fix failing test for new rustc
+
 ## [0.17.0-beta.15](https://github.com/avl/savefile/compare/savefile-derive-v0.17.0-beta.14...savefile-derive-v0.17.0-beta.15) - 2024-04-30
 
 ### Fixed

--- a/savefile-derive/Cargo.toml
+++ b/savefile-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile-derive"
-version = "0.17.1"
+version = "0.17.2"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 
 description = "Custom derive macros for savefile crate - simple, convenient, fast, versioned, binary serialization/deserialization library."

--- a/savefile-test/Cargo.toml
+++ b/savefile-test/Cargo.toml
@@ -12,7 +12,7 @@ nightly=["savefile/nightly"]
 
 [dependencies]
 savefile = { path = "../savefile", features = ["size_sanity_checks", "encryption", "compression","bit-set","bit-vec","rustc-hash","serde_derive", "quickcheck"]}
-savefile-derive = { path = "../savefile-derive", version = "=0.17.1" }
+savefile-derive = { path = "../savefile-derive", version = "=0.17.2" }
 savefile-abi = { path = "../savefile-abi" }
 bit-vec = "0.6"
 arrayvec="0.7"

--- a/savefile/CHANGELOG.md
+++ b/savefile/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2](https://github.com/avl/savefile/compare/savefile-v0.17.1...savefile-v0.17.2) - 2024-05-05
+
+### Fixed
+- Make comment clearer
+
+### Other
+- Fix deprecation of helper struct
+- merge
+- merge
+
 ## [0.17.1](https://github.com/avl/savefile/compare/savefile-v0.17.0...savefile-v0.17.1) - 2024-05-01
 
 ### Other

--- a/savefile/CHANGELOG.md
+++ b/savefile/CHANGELOG.md
@@ -11,11 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Make comment clearer
 
-### Other
-- Fix deprecation of helper struct
-- merge
-- merge
-
 ## [0.17.1](https://github.com/avl/savefile/compare/savefile-v0.17.0...savefile-v0.17.1) - 2024-05-01
 
 ### Other

--- a/savefile/Cargo.toml
+++ b/savefile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile"
-version = "0.17.1"
+version = "0.17.2"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 documentation = "https://docs.rs/savefile/"
 homepage = "https://github.com/avl/savefile/"
@@ -54,13 +54,13 @@ bit-set = {version = "0.5", optional = true}
 rustc-hash = {version = "1.1", optional = true}
 memoffset = "0.9"
 byteorder = "1.4"
-savefile-derive = {path="../savefile-derive", version = "=0.17.1", optional = true }
+savefile-derive = {path="../savefile-derive", version = "=0.17.2", optional = true }
 serde_derive = {version= "1.0", optional = true}
 serde = {version= "1.0", optional = true}
 quickcheck = {version= "1.0", optional = true}
 
 [dev-dependencies]
-savefile-derive = { path="../savefile-derive", version = "=0.17.1" }
+savefile-derive = { path="../savefile-derive", version = "=0.17.2" }
 
 [build-dependencies]
 rustc_version="0.2"


### PR DESCRIPTION
## 🤖 New release
* `savefile`: 0.17.1 -> 0.17.2
* `savefile-derive`: 0.17.1 -> 0.17.2
* `savefile-abi`: 0.17.1 -> 0.17.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `savefile`
<blockquote>

## [0.17.2](https://github.com/avl/savefile/compare/savefile-v0.17.1...savefile-v0.17.2) - 2024-05-05

### Fixed
- Make comment clearer

### Other
- Fix deprecation of helper struct
- merge
- merge
</blockquote>

## `savefile-derive`
<blockquote>

## [0.17.2](https://github.com/avl/savefile/compare/savefile-derive-v0.17.1...savefile-derive-v0.17.2) - 2024-05-05

### Other
- Fix failing test for new rustc
</blockquote>

## `savefile-abi`
<blockquote>

## [0.17.2](https://github.com/avl/savefile/compare/savefile-abi-v0.17.1...savefile-abi-v0.17.2) - 2024-05-05

### Other
- updated the following local packages: savefile, savefile-derive
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).