### PR TITLE
Fix failing test new rustc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,27 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alkahest"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631a0c0a3e1a64558bb2552a3893102c428d5e88a0e3f0a6979a7a67328c1e1b"
-dependencies = [
- "alkahest-proc",
- "bytemuck",
-]
-
-[[package]]
-name = "alkahest-proc"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8087db15c316edb2432048cfd2f3f848ee22887f9d717d7375bf7b666a59e7e7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,12 +58,6 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
-name = "bytemuck"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 
 [[package]]
 name = "byteorder"
@@ -550,7 +523,6 @@ dependencies = [
 name = "savefile-min-build"
 version = "0.1.0"
 dependencies = [
- "alkahest",
  "savefile",
  "savefile-abi",
  "savefile-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "savefile"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-abi"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "byteorder",
  "libloading",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-derive"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/compile_tests/Cargo.lock
+++ b/compile_tests/Cargo.lock
@@ -463,7 +463,7 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "savefile"
-version = "0.17.0-beta.15"
+version = "0.17.1"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-abi"
-version = "0.17.0-beta.15"
+version = "0.17.1"
 dependencies = [
  "byteorder",
  "libloading",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-derive"
-version = "0.17.0-beta.15"
+version = "0.17.1"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/savefile-abi/CHANGELOG.md
+++ b/savefile-abi/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2](https://github.com/avl/savefile/compare/savefile-abi-v0.17.1...savefile-abi-v0.17.2) - 2024-05-05
+
+### Other
+- updated the following local packages: savefile, savefile-derive
+
 ## [0.17.1](https://github.com/avl/savefile/compare/savefile-abi-v0.17.0...savefile-abi-v0.17.1) - 2024-05-01
 
 ### Other

--- a/savefile-abi/Cargo.toml
+++ b/savefile-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile-abi"
-version = "0.17.1"
+version = "0.17.2"
 edition = "2021"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 documentation = "https://docs.rs/savefile-abi/"
@@ -16,7 +16,7 @@ keywords = ["dylib", "dlopen", "ffi"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-savefile = { path="../savefile", version = "=0.17.1" }
-savefile-derive = { path="../savefile-derive", version = "=0.17.1" }
+savefile = { path="../savefile", version = "=0.17.2" }
+savefile-derive = { path="../savefile-derive", version = "=0.17.2" }
 byteorder = "1.4"
 libloading = "0.8"

--- a/savefile-derive/CHANGELOG.md
+++ b/savefile-derive/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2](https://github.com/avl/savefile/compare/savefile-derive-v0.17.1...savefile-derive-v0.17.2) - 2024-05-05
+
+### Other
+- Fix failing test for new rustc
+
 ## [0.17.0-beta.15](https://github.com/avl/savefile/compare/savefile-derive-v0.17.0-beta.14...savefile-derive-v0.17.0-beta.15) - 2024-04-30
 
 ### Fixed

--- a/savefile-derive/Cargo.toml
+++ b/savefile-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile-derive"
-version = "0.17.1"
+version = "0.17.2"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 
 description = "Custom derive macros for savefile crate - simple, convenient, fast, versioned, binary serialization/deserialization library."

--- a/savefile-derive/src/lib.rs
+++ b/savefile-derive/src/lib.rs
@@ -585,7 +585,7 @@ pub fn savefile_abi_export(item: proc_macro::TokenStream) -> proc_macro::TokenSt
         const _:() = {
             #uses
             #[automatically_derived]
-            unsafe impl AbiExportableImplementation for #implementing_type {
+            unsafe impl AbiExportableImplementation for #implementing_type where #implementing_type: Default + #trait_type {
                 const ABI_ENTRY: unsafe extern "C" fn (AbiProtocol) = #abi_entry;
                 type AbiInterface = dyn #trait_type;
 

--- a/savefile-min-build/Cargo.toml
+++ b/savefile-min-build/Cargo.toml
@@ -9,4 +9,3 @@ edition = "2021"
 savefile = { path = "../savefile", default-features = false }
 savefile-abi = { path = "../savefile-abi" }
 savefile-derive = {path = "../savefile-derive"}
-alkahest = { version = "0.1", features=["derive"] }

--- a/savefile-min-build/src/lib.rs
+++ b/savefile-min-build/src/lib.rs
@@ -1,131 +1,14 @@
-/*#![allow(soft_unstable)]
-#![feature(test)]
-extern crate alkahest;
-
-extern crate test;
-
-use std::hint::black_box;
-use test::Bencher;
-
 
 use savefile_derive::Savefile;
-use savefile::Packed;
 
-#[derive(Clone, Copy, Debug, PartialEq,Default)]
-#[derive(alkahest::Schema)]
-#[derive(Savefile)]
-pub struct Vector3 {
-    pub x: f32,
-    pub y: f32,
-    pub z: f32,
+
+#[derive(Debug, Savefile, PartialEq)]
+pub enum TestStructEnum {
+    Variant2 { a: u8, b: u8 },
 }
 
-impl alkahest::Pack<Vector3> for Vector3 {
-    #[inline]
-    fn pack(self, offset: usize, output: &mut [u8]) -> (alkahest::Packed<Self>, usize) {
-        Vector3Pack {
-            x: self.x,
-            y: self.y,
-            z: self.z,
-        }
-            .pack(offset, output)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq,Default)]
-#[derive(alkahest::Schema)]
-#[derive(Savefile)]
-pub struct Triangle {
-    pub v0: Vector3,
-    pub v1: Vector3,
-    pub v2: Vector3,
-    pub normal: Vector3,
-}
-impl alkahest::Pack<Triangle> for &'_ Triangle {
-    #[inline]
-    fn pack(self, offset: usize, output: &mut [u8]) -> (alkahest::Packed<Triangle>, usize) {
-        TrianglePack {
-            v0: self.v0,
-            v1: self.v1,
-            v2: self.v2,
-            normal: self.normal,
-        }
-            .pack(offset, output)
-    }
-}
-#[derive(Clone, Debug, PartialEq,Default)]
-#[derive(Savefile)]
-pub struct Mesh {
-    pub triangles: Vec<Triangle>,
-}
-#[derive(alkahest::Schema)]
-pub struct MeshSchema {
-    pub triangles: alkahest::Seq<Triangle>,
-}
-
-impl alkahest::Pack<MeshSchema> for &'_ Mesh {
-    #[inline]
-    fn pack(self, offset: usize, output: &mut [u8]) -> (alkahest::Packed<MeshSchema>, usize) {
-        MeshSchemaPack {
-            triangles: self.triangles.iter(),
-        }
-            .pack(offset, output)
-    }
-}
-
-
-pub fn generate_mesh() -> Mesh {
-
-    let mut mesh = Mesh {
-        triangles: vec![]
-    };
-    const TRIANGLES: usize = 125_000;
-    for _ in 0..TRIANGLES {
-        mesh.triangles.push(Triangle::default())
-    }
-
-    mesh
-}
-#[bench]
-fn bench_alkahest(b: &mut Bencher) {
-    const BUFFER_LEN: usize = 10_000_000;
-    let mesh = generate_mesh();
-    let mut buffer = vec![0; BUFFER_LEN];
-    b.iter(move || {
-        alkahest::write::<MeshSchema, _>(black_box(&mut buffer), black_box(&mesh));
-    });
-}
-
-
-#[bench]
-fn bench_savefile(b: &mut Bencher) {
-    let mesh = generate_mesh();
-    let mut encoded: Vec<u8> = Vec::with_capacity(10_000_000);
-    assert!(unsafe { Triangle::repr_c_optimization_safe(0).is_yes() } );
-    b.iter(move || {
-        /*let l = mesh.triangles.len();
-        let data_ptr = mesh.triangles.as_ptr() as *const u8;
-        let data_len = l * std::mem::size_of::<Triangle>();
-        encoded
-        serializer.write_buf(std::slice::from_raw_parts(
-            self.as_ptr() as *const u8,
-            std::mem::size_of::<T>() * l,
-        ))*/
-        encoded.clear();
-
-        savefile::save_noschema(black_box(&mut encoded), 0, black_box(&mesh)).unwrap();
-    })
-}
-
-/*
-
-
-
-
-fn stuff<T>() -> T {
-    todo!()
-}
-*/
 #[test]
-fn dummy() {
-}*/
+fn test() {
+
+}
+

--- a/savefile-test/Cargo.toml
+++ b/savefile-test/Cargo.toml
@@ -12,7 +12,7 @@ nightly=["savefile/nightly"]
 
 [dependencies]
 savefile = { path = "../savefile", features = ["size_sanity_checks", "encryption", "compression","bit-set","bit-vec","rustc-hash","serde_derive", "quickcheck"]}
-savefile-derive = { path = "../savefile-derive", version = "=0.17.1" }
+savefile-derive = { path = "../savefile-derive", version = "=0.17.2" }
 savefile-abi = { path = "../savefile-abi" }
 bit-vec = "0.6"
 arrayvec="0.7"

--- a/savefile-test/src/ext_benchmark.rs
+++ b/savefile-test/src/ext_benchmark.rs
@@ -212,6 +212,7 @@ fn bench_ext_triangle(b: &mut Bencher) {
     let mesh = generate_mesh();
     let mut encoded: Vec<u8> = Vec::new();
     b.iter(move || {
+        encoded.clear();
         savefile::save_noschema(black_box(&mut encoded), 0, black_box(&mesh)).unwrap();
     })
 }

--- a/savefile/CHANGELOG.md
+++ b/savefile/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2](https://github.com/avl/savefile/compare/savefile-v0.17.1...savefile-v0.17.2) - 2024-05-05
+
+### Fixed
+- Make comment clearer
+
 ## [0.17.1](https://github.com/avl/savefile/compare/savefile-v0.17.0...savefile-v0.17.1) - 2024-05-01
 
 ### Other

--- a/savefile/Cargo.toml
+++ b/savefile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile"
-version = "0.17.1"
+version = "0.17.2"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 documentation = "https://docs.rs/savefile/"
 homepage = "https://github.com/avl/savefile/"
@@ -54,13 +54,13 @@ bit-set = {version = "0.5", optional = true}
 rustc-hash = {version = "1.1", optional = true}
 memoffset = "0.9"
 byteorder = "1.4"
-savefile-derive = {path="../savefile-derive", version = "=0.17.1", optional = true }
+savefile-derive = {path="../savefile-derive", version = "=0.17.2", optional = true }
 serde_derive = {version= "1.0", optional = true}
 serde = {version= "1.0", optional = true}
 quickcheck = {version= "1.0", optional = true}
 
 [dev-dependencies]
-savefile-derive = { path="../savefile-derive", version = "=0.17.1" }
+savefile-derive = { path="../savefile-derive", version = "=0.17.2" }
 
 [build-dependencies]
 rustc_version="0.2"

--- a/savefile/src/lib.rs
+++ b/savefile/src/lib.rs
@@ -1238,7 +1238,15 @@ pub trait Packed {
     }
 }
 
+/// This just exists to make sure that no one can actually implement the ReprC-trait placeholder.
+#[doc(hidden)]
 #[deprecated(since="0.17", note="The 'Packed' trait has been renamed to 'Packed'.")]
+pub struct DeliberatelyUnimplementable{
+    #[allow(dead_code)]
+    private: ()
+}
+
+#[deprecated(since="0.17", note="The 'ReprC' trait has been renamed to 'Packed'.")]
 #[doc(hidden)]
 pub trait ReprC {
     #[deprecated(since="0.17", note="The 'Packed' trait has been renamed to 'Packed'.")]

--- a/savefile/src/lib.rs
+++ b/savefile/src/lib.rs
@@ -1240,7 +1240,7 @@ pub trait Packed {
     }
 }
 
-/// This just exists to make sure that no one can implement the ReprC-trait placeholder.
+/// This just exists to make sure that no one can actually implement the ReprC-trait placeholder.
 #[doc(hidden)]
 #[deprecated(since="0.17", note="The 'Packed' trait has been renamed to 'Packed'.")]
 pub struct DeliberatelyUnimplementable{

--- a/savefile/src/lib.rs
+++ b/savefile/src/lib.rs
@@ -1242,7 +1242,7 @@ pub trait Packed {
 
 /// This just exists to make sure that no one can actually implement the ReprC-trait placeholder.
 #[doc(hidden)]
-#[deprecated(since="0.17", note="The 'Packed' trait has been renamed to 'Packed'.")]
+#[deprecated(since="0.17", note="The 'ReprC' trait has been renamed to 'Packed'.")]
 pub struct DeliberatelyUnimplementable{
     #[allow(dead_code)]
     private: ()
@@ -1254,6 +1254,7 @@ pub trait ReprC {
     #[deprecated(since="0.17", note="The 'ReprC' trait has been renamed to 'Packed'.")]
     #[doc(hidden)]
     #[allow(non_snake_case)]
+    #[allow(deprecated)]
     fn this_is_a_placeholder__if_you_see_this_it_is_likely_that_you_have_code_that_refers_to_ReprC_trait__this_trait_has_been_renamed_to__Packed() -> DeliberatelyUnimplementable;
     unsafe fn repr_c_optimization_safe(_version: u32) -> IsPacked {
         IsPacked::no()


### PR DESCRIPTION
Diagnostics for misuse of  savefile_abi_export!-macro had become worse with the new rustc (1.78).
This was caught by a test, and is fixed by this PR. Also, some cleanup of test-code in one of the test-projects, and a minor improvement of doc-comments.
