### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-derive"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "savefile"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-abi"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "byteorder",
  "libloading",

--- a/savefile-abi/CHANGELOG.md
+++ b/savefile-abi/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.5](https://github.com/avl/savefile/compare/savefile-abi-v0.17.4...savefile-abi-v0.17.5) - 2024-07-02
+
+### Other
+- updated the following local packages: savefile
+
 ## [0.17.4](https://github.com/avl/savefile/compare/savefile-abi-v0.17.3...savefile-abi-v0.17.4) - 2024-05-12
 
 ### Added

--- a/savefile-abi/Cargo.toml
+++ b/savefile-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile-abi"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2021"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 documentation = "https://docs.rs/savefile-abi/"
@@ -17,7 +17,7 @@ keywords = ["dylib", "dlopen", "ffi"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-savefile = { path="../savefile", version = "=0.17.4" }
+savefile = { path="../savefile", version = "=0.17.5" }
 savefile-derive = { path="../savefile-derive", version = "=0.17.4" }
 byteorder = "1.4"
 libloading = "0.8"

--- a/savefile-abi/Cargo.toml
+++ b/savefile-abi/Cargo.toml
@@ -18,7 +18,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 savefile = { path="../savefile", version = "=0.17.5" }
-savefile-derive = { path="../savefile-derive", version = "=0.17.4" }
+savefile-derive = { path="../savefile-derive", version = "=0.17.5" }
 byteorder = "1.4"
 libloading = "0.8"
 

--- a/savefile-derive/Cargo.toml
+++ b/savefile-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile-derive"
-version = "0.17.4"
+version = "0.17.5"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 repository = "https://github.com/avl/savefile"
 rust-version = "1.74"

--- a/savefile-test/Cargo.toml
+++ b/savefile-test/Cargo.toml
@@ -12,7 +12,7 @@ nightly=["savefile/nightly"]
 
 [dependencies]
 savefile = { path = "../savefile", features = ["size_sanity_checks", "encryption", "compression","bit-set","bit-vec","rustc-hash","serde_derive", "quickcheck"]}
-savefile-derive = { path = "../savefile-derive", version = "=0.17.4" }
+savefile-derive = { path = "../savefile-derive", version = "=0.17.5" }
 savefile-abi = { path = "../savefile-abi" }
 bit-vec = "0.6"
 arrayvec="0.7"

--- a/savefile/CHANGELOG.md
+++ b/savefile/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.5](https://github.com/avl/savefile/compare/savefile-v0.17.4...savefile-v0.17.5) - 2024-07-02
+
+### Added
+- Support for Duration and SystemTime
+
 ## [0.17.4](https://github.com/avl/savefile/compare/savefile-v0.17.3...savefile-v0.17.4) - 2024-05-12
 
 ### Added

--- a/savefile/Cargo.toml
+++ b/savefile/Cargo.toml
@@ -59,13 +59,13 @@ bit-set = {version = "0.5", optional = true}
 rustc-hash = {version = "1.1", optional = true}
 memoffset = "0.9"
 byteorder = "1.4"
-savefile-derive = {path="../savefile-derive", version = "=0.17.4", optional = true }
+savefile-derive = {path="../savefile-derive", version = "=0.17.5", optional = true }
 serde_derive = {version= "1.0", optional = true}
 serde = {version= "1.0", optional = true}
 quickcheck = {version= "1.0", optional = true}
 
 [dev-dependencies]
-savefile-derive = { path="../savefile-derive", version = "=0.17.4" }
+savefile-derive = { path="../savefile-derive", version = "=0.17.5" }
 
 [build-dependencies]
 rustc_version="0.2"

--- a/savefile/Cargo.toml
+++ b/savefile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile"
-version = "0.17.4"
+version = "0.17.5"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 documentation = "https://docs.rs/savefile/"
 homepage = "https://github.com/avl/savefile/"


### PR DESCRIPTION
## 🤖 New release
* `savefile`: 0.17.4 -> 0.17.5
* `savefile-abi`: 0.17.4 -> 0.17.5
* `savefile-derive`: 0.17.4 -> 0.17.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `savefile`
<blockquote>

## [0.17.5](https://github.com/avl/savefile/compare/savefile-v0.17.4...savefile-v0.17.5) - 2024-07-02

### Added
- Support for Duration and SystemTime
</blockquote>

## `savefile-abi`
<blockquote>

## [0.17.5](https://github.com/avl/savefile/compare/savefile-abi-v0.17.4...savefile-abi-v0.17.5) - 2024-07-02

### Other
- updated the following local packages: savefile
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).