### PR TITLE
build: :arrow_up: Switch to proc-macro-error2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,27 +397,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
- "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "proc-macro-error2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
+ "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "version_check",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -653,7 +651,7 @@ dependencies = [
 name = "savefile-derive"
 version = "0.17.8"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -811,12 +809,6 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/savefile-derive/Cargo.toml
+++ b/savefile-derive/Cargo.toml
@@ -27,5 +27,5 @@ proc-macro = true
 quote = "1.0"
 syn = { version = "1.0" , features = ["full","extra-traits"]}
 proc-macro2 = { version = "1.0", features = ["nightly"] }
-proc-macro-error = "1.0"
+proc-macro-error2 = "2.0.1"
 

--- a/savefile-derive/src/lib.rs
+++ b/savefile-derive/src/lib.rs
@@ -20,7 +20,7 @@ extern crate proc_macro2;
 extern crate quote;
 extern crate syn;
 #[macro_use]
-extern crate proc_macro_error;
+extern crate proc_macro_error2;
 
 use common::{
     check_is_remove, compile_time_check_reprc, compile_time_size, get_extra_where_clauses, parse_attr_tag,


### PR DESCRIPTION
Switch to using [proc-macro-error2](https://crates.io/crates/proc-macro-error2) as proc-macro-error is [no longer maintained](https://rustsec.org/advisories/RUSTSEC-2024-0370.html).
Should be a drop in replacement.

Everything seems to be compiling and passing on my end. Minus `test_systemtime`, but that also fails without the change.

Please let me know if there are any issues with this.
Thanks!
