### PR TITLE
chore: release v0.17.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "savefile"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "arrayvec",
  "bit-set 0.5.3",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-abi"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "byteorder",
  "libloading",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-derive"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",

--- a/savefile-abi/Cargo.toml
+++ b/savefile-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile-abi"
-version = "0.17.8"
+version = "0.17.9"
 edition = "2021"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 documentation = "https://docs.rs/savefile-abi/"
@@ -17,8 +17,8 @@ keywords = ["dylib", "dlopen", "ffi"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-savefile = { path="../savefile", version = "=0.17.8" }
-savefile-derive = { path="../savefile-derive", version = "=0.17.8" }
+savefile = { path="../savefile", version = "=0.17.9" }
+savefile-derive = { path="../savefile-derive", version = "=0.17.9" }
 byteorder = "1.4"
 libloading = "0.8"
 

--- a/savefile-derive/Cargo.toml
+++ b/savefile-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile-derive"
-version = "0.17.8"
+version = "0.17.9"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 repository = "https://github.com/avl/savefile"
 rust-version = "1.74"

--- a/savefile-test/Cargo.toml
+++ b/savefile-test/Cargo.toml
@@ -12,7 +12,7 @@ nightly=["savefile/nightly"]
 
 [dependencies]
 savefile = { path = "../savefile", features = ["size_sanity_checks", "encryption", "compression","bit-set","bit-vec","rustc-hash","serde_derive", "quickcheck", "nalgebra"]}
-savefile-derive = { path = "../savefile-derive", version = "=0.17.8" }
+savefile-derive = { path = "../savefile-derive", version = "=0.17.9" }
 savefile-abi = { path = "../savefile-abi" }
 bit-vec = "0.8"
 arrayvec="0.7"

--- a/savefile/Cargo.toml
+++ b/savefile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savefile"
-version = "0.17.8"
+version = "0.17.9"
 authors = ["Anders Musikka <anders@andersmusikka.se>"]
 documentation = "https://docs.rs/savefile/"
 homepage = "https://github.com/avl/savefile/"
@@ -63,13 +63,13 @@ bit-set08 = {package="bit-set", version = "0.8", optional = true}
 rustc-hash = {version = "1.1", optional = true}
 memoffset = "0.9"
 byteorder = "1.4"
-savefile-derive = {path="../savefile-derive", version = "=0.17.8", optional = true }
+savefile-derive = {path="../savefile-derive", version = "=0.17.9", optional = true }
 serde_derive = {version= "1.0", optional = true}
 serde = {version= "1.0", optional = true}
 quickcheck = {version= "1.0", optional = true}
 
 [dev-dependencies]
-savefile-derive = { path="../savefile-derive", version = "=0.17.8" }
+savefile-derive = { path="../savefile-derive", version = "=0.17.9" }
 
 [build-dependencies]
 rustc_version="0.2"


### PR DESCRIPTION
## 🤖 New release
* `savefile-derive`: 0.17.8 -> 0.17.9
* `savefile`: 0.17.8 -> 0.17.9
* `savefile-abi`: 0.17.8 -> 0.17.9

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).