### PR TITLE
Implement `doc_hidden` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 This file contains information about changes in each version of savefile.
 
+## 0.20.1
+
+Add new `doc_hidden`-attribute, allowing generated impls to have `#[doc(hidden)]`. This hides
+the impls from your docs.
+
 ## 0.20.0
  
  * Removes the requirement that items in collections be `'static`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "savefile"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arrayvec",
  "bit-set 0.5.3",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-abi"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-derive"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-test"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arrayvec",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["compile_tests", "savefile_abi_example"]
 resolver = "2"
 
 [workspace.package]
-version = "0.20.0"
+version = "0.20.1"
 
 [profile.dev.package]
 insta.opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
     "savefile-abi-min-lib", 
     "savefile-abi-min-lib-impl"
 ]
-exclude = ["compile_tests"]
+exclude = ["compile_tests", "savefile_abi_example"]
 resolver = "2"
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -108,11 +108,6 @@ Features savefile does not have, and will not have:
 
 # Upgrade Guide
 
-## Upgrading from pre 0.20.0:
-
-asdf
-
-
 ## Upgrading from pre 0.16.x:
 
 ### "the trait bound `MyStuff: WithSchema` is not satisfied"

--- a/savefile-abi/Cargo.toml
+++ b/savefile-abi/Cargo.toml
@@ -17,8 +17,8 @@ keywords = ["dylib", "dlopen", "ffi"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-savefile = { path="../savefile", version = "=0.20.0" }
-savefile-derive = { path="../savefile-derive", version = "=0.20.0" }
+savefile = { path="../savefile", version = "=0.20.1" }
+savefile-derive = { path="../savefile-derive", version = "=0.20.1" }
 byteorder = "1.4"
 libloading = "0.8"
 bytes = {version = "1.8", optional = true }

--- a/savefile-abi/src/lib.rs
+++ b/savefile-abi/src/lib.rs
@@ -328,7 +328,7 @@ impl BoxedAsyncInterface for SimpleImpl {
 
 ```
 
-It also supports the #[async_trait] proc macro crate. Use it like this:
+It also supports the `#[async_trait]` proc macro crate. Use it like this:
 
 ```rust
 use async_trait::async_trait;

--- a/savefile-derive/src/deserialize.rs
+++ b/savefile-derive/src/deserialize.rs
@@ -1,5 +1,5 @@
 use crate::common::{check_is_remove, get_extra_where_clauses, parse_attr_tag, FieldInfo, RemovedType};
-use crate::get_enum_size;
+use crate::{doc_hidden, get_enum_size};
 use proc_macro2::{Literal, TokenStream};
 use syn::spanned::Spanned;
 use syn::DeriveInput;
@@ -122,6 +122,7 @@ pub fn savefile_derive_crate_deserialize(input: DeriveInput) -> TokenStream {
 
     let name = &input.ident;
 
+    let doc_hidden = doc_hidden(&input.attrs);
     let generics = &input.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let extra_where = get_extra_where_clauses(
@@ -216,6 +217,7 @@ pub fn savefile_derive_crate_deserialize(input: DeriveInput) -> TokenStream {
                 const #dummy_const: () = {
                     #uses
                     #[automatically_derived]
+                    #doc_hidden
                     impl #impl_generics #deserialize for #name #ty_generics #where_clause #extra_where {
                         #[allow(unused_comparisons, unused_variables)]
                         fn deserialize(deserializer: &mut #deserializer) -> Result<Self,#saveerr> {
@@ -280,6 +282,7 @@ pub fn savefile_derive_crate_deserialize(input: DeriveInput) -> TokenStream {
                 const #dummy_const: () = {
                         #uses
                         #[automatically_derived]
+                        #doc_hidden
                         impl #impl_generics #deserialize for #name #ty_generics #where_clause #extra_where {
                         #[allow(unused_comparisons, unused_variables)]
                         fn deserialize(deserializer: &mut #deserializer) -> Result<Self,#saveerr> {

--- a/savefile-derive/src/serialize.rs
+++ b/savefile-derive/src/serialize.rs
@@ -1,8 +1,8 @@
 use proc_macro2::{Span, TokenStream};
-use syn::DeriveInput;
+use syn::{Attribute, DeriveInput};
 
 use crate::common::{get_extra_where_clauses, parse_attr_tag, FieldInfo};
-use crate::get_enum_size;
+use crate::{doc_hidden, get_enum_size};
 use crate::implement_fields_serialize;
 use syn::spanned::Spanned;
 
@@ -11,6 +11,8 @@ pub(super) fn savefile_derive_crate_serialize(input: DeriveInput) -> TokenStream
     let name_str = name.to_string();
 
     let generics = &input.generics;
+
+    let doc_hidden = doc_hidden(&input.attrs);
 
     let span = proc_macro2::Span::call_site();
     let defspan = proc_macro2::Span::call_site();
@@ -137,6 +139,7 @@ pub(super) fn savefile_derive_crate_serialize(input: DeriveInput) -> TokenStream
                     #uses
 
                     #[automatically_derived]
+                    #doc_hidden
                     impl #impl_generics #serialize for #name #ty_generics #where_clause #extra_where {
 
                         #[allow(unused_comparisons, unused_variables)]
@@ -203,6 +206,7 @@ pub(super) fn savefile_derive_crate_serialize(input: DeriveInput) -> TokenStream
                     #uses
 
                     #[automatically_derived]
+                    #doc_hidden
                     impl #impl_generics #serialize for #name #ty_generics #where_clause #extra_where {
                         #[allow(unused_comparisons, unused_variables)]
                         fn serialize(&self, serializer: &mut #serializer)  -> #saveerr {

--- a/savefile-min-build/src/lib.rs
+++ b/savefile-min-build/src/lib.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 
 #[derive(Savefile, Debug, PartialEq)]
 #[repr(u32)]
+#[savefile_doc_hidden]
 pub enum Example {
     A(u32, u32),
     B { a: u32, b: u32, c: u32 },

--- a/savefile-test/Cargo.toml
+++ b/savefile-test/Cargo.toml
@@ -14,7 +14,7 @@ nightly=["savefile/nightly"]
 
 [dependencies]
 savefile = { path = "../savefile", features = ["size_sanity_checks", "encryption", "compression","bit-set","bit-vec","rustc-hash","serde_derive", "quickcheck", "nalgebra"]}
-savefile-derive = { path = "../savefile-derive", version = "=0.20.0" }
+savefile-derive = { path = "../savefile-derive", version = "=0.20.1" }
 savefile-abi = { path = "../savefile-abi" , features = ["bytes"]}
 bit-vec = "0.8"
 arrayvec="0.7"

--- a/savefile/Cargo.toml
+++ b/savefile/Cargo.toml
@@ -62,7 +62,7 @@ bit-set08 = {package="bit-set", version = "0.8", optional = true}
 rustc-hash = {version = "2.1.0", optional = true}
 memoffset = "0.9"
 byteorder = "1.4"
-savefile-derive = {path="../savefile-derive", version = "=0.20.0", optional = true }
+savefile-derive = {path="../savefile-derive", version = "=0.20.1", optional = true }
 serde_derive = {version= "1.0", optional = true}
 serde = {version= "1.0", optional = true}
 quickcheck = {version= "1.0", optional = true}
@@ -70,7 +70,7 @@ emath = {version = "0.30", optional = true}
 ecolor = {version = "0.30", optional = true}
 
 [dev-dependencies]
-savefile-derive = { path="../savefile-derive", version = "=0.20.0" }
+savefile-derive = { path="../savefile-derive", version = "=0.20.1" }
 
 [build-dependencies]
 rustc_version="0.4"

--- a/savefile/src/lib.rs
+++ b/savefile/src/lib.rs
@@ -629,6 +629,23 @@ Using 'savefile_require_fast' is not unsafe, although it used to be in an old ve
 Since the speedups it produces are now produced regardless, it is mostly recommended to not use
 savefile_require_fast, unless compilation failure on bad alignment is desired.
 
+### The `doc_hidden` attribute
+
+When using the savefile derive macro, you can specify the `doc_hidden` attribute to make
+the generated implementations have the `#[doc(hidden)]` attribute. This hides the implementation
+of the savefile-traits from the docs. This can be useful if the fact that your public types
+implement the savefile traits is meant to be an internal implementation detial.
+
+Example:
+```rust
+use savefile::prelude::*;
+#[derive(Savefile)]
+#[savefile_doc_hidden]
+pub struct Example {
+    field: u32,
+}
+
+```
 
 # Custom serialization
 

--- a/savefile/src/lib.rs
+++ b/savefile/src/lib.rs
@@ -644,7 +644,6 @@ use savefile::prelude::*;
 pub struct Example {
     field: u32,
 }
-
 ```
 
 # Custom serialization

--- a/savefile_abi_example/app/Cargo.toml
+++ b/savefile_abi_example/app/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-savefile-abi = "0.18"
-savefile = "0.18"
-savefile-derive = "0.18"
+savefile-abi.path = "../../savefile-abi"
+savefile.path = "../../savefile"
+savefile-derive.path= "../../savefile-derive"
 interface_crate = { path = "../interface_crate" }
 
 

--- a/savefile_abi_example/implementation_crate/Cargo.toml
+++ b/savefile_abi_example/implementation_crate/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-savefile-abi = "0.18"
-savefile = "0.18"
-savefile-derive = "0.18"
+savefile-abi.path = "../../savefile-abi"
+savefile.path = "../../savefile"
+savefile-derive.path= "../../savefile-derive"
 interface_crate = { path = "../interface_crate" }
 

--- a/savefile_abi_example/implementation_crate/src/lib.rs
+++ b/savefile_abi_example/implementation_crate/src/lib.rs
@@ -2,7 +2,7 @@ use interface_crate::{AdderInterface};
 use savefile_derive::savefile_abi_export;
 
 #[derive(Default)]
-struct MyAdder { }
+pub struct MyAdder { }
 
 impl AdderInterface for MyAdder {
     fn add(&self, x: u32, y: u32) -> u32 {

--- a/savefile_abi_example/interface_crate/Cargo.toml
+++ b/savefile_abi_example/interface_crate/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-savefile-abi = "0.18"
-savefile = "0.18"
-savefile-derive = "0.18"
+savefile-abi.path = "../../savefile-abi"
+savefile.path = "../../savefile"
+savefile-derive.path= "../../savefile-derive"
 


### PR DESCRIPTION
New attribute:

```rust
use savefile::prelude::*;
#[derive(Savefile)]
#[savefile_doc_hidden]
pub struct Example {
    field: u32,
}
```
Hides impl of traits from docs.
