### PR TITLE
Fix ignore attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 This file contains information about changes in each version of savefile.
 
+## 0.20.2
+
+Fix bug where `#[savefile_ignore]` didn't work if the ignored field was first or last,
+and its datatype did not implement the `Packed` trait.
+
 ## 0.20.1
 
 Add new `doc_hidden`-attribute, allowing generated impls to have `#[doc(hidden)]`. This hides

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "savefile"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "arrayvec",
  "bit-set 0.5.3",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-abi"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-derive"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "savefile-test"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "arrayvec",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["compile_tests", "savefile_abi_example"]
 resolver = "2"
 
 [workspace.package]
-version = "0.20.1"
+version = "0.20.2"
 
 [profile.dev.package]
 insta.opt-level = 3

--- a/savefile-abi/Cargo.toml
+++ b/savefile-abi/Cargo.toml
@@ -17,8 +17,8 @@ keywords = ["dylib", "dlopen", "ffi"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-savefile = { path="../savefile", version = "=0.20.1" }
-savefile-derive = { path="../savefile-derive", version = "=0.20.1" }
+savefile = { path="../savefile", version = "=0.20.2" }
+savefile-derive = { path="../savefile-derive", version = "=0.20.2" }
 byteorder = "1.4"
 libloading = "0.8"
 bytes = {version = "1.8", optional = true }

--- a/savefile-test/Cargo.toml
+++ b/savefile-test/Cargo.toml
@@ -14,7 +14,7 @@ nightly=["savefile/nightly"]
 
 [dependencies]
 savefile = { path = "../savefile", features = ["size_sanity_checks", "encryption", "compression","bit-set","bit-vec","rustc-hash","serde_derive", "quickcheck", "nalgebra"]}
-savefile-derive = { path = "../savefile-derive", version = "=0.20.1" }
+savefile-derive = { path = "../savefile-derive", version = "=0.20.2" }
 savefile-abi = { path = "../savefile-abi" , features = ["bytes"]}
 bit-vec = "0.8"
 arrayvec="0.7"

--- a/savefile-test/src/lib.rs
+++ b/savefile-test/src/lib.rs
@@ -1565,6 +1565,52 @@ pub fn test_struct_with_ignored_member() {
     });
 }
 
+#[derive(Default, PartialEq, Debug)]
+struct NonSerializableZeroSized;
+#[derive(Savefile, PartialEq, Debug)]
+struct TestIgnoreNonSerializableZeroSized {
+    a: f64,
+    b: f64,
+    #[savefile_ignore]
+    #[savefile_introspect_ignore]
+    cached_product: NonSerializableZeroSized,
+}
+
+#[test]
+pub fn test_struct_with_ignored_member2() {
+    unsafe {
+        assert!(TestIgnoreNonSerializableZeroSized::repr_c_optimization_safe(0).is_yes());
+    }
+    assert_roundtrip(TestIgnoreNonSerializableZeroSized {
+        a: 42.0,
+        b: 43.0,
+        cached_product: NonSerializableZeroSized,
+    });
+}
+
+#[derive(Default, PartialEq, Debug)]
+struct NonSerializableNonZeroSized(u8);
+#[derive(Savefile, PartialEq, Debug)]
+struct TestIgnoreNonSerializableNonZeroSized {
+    a: f64,
+    b: f64,
+    #[savefile_ignore]
+    #[savefile_introspect_ignore]
+    cached_product: NonSerializableNonZeroSized,
+}
+
+#[test]
+pub fn test_struct_with_ignored_member3() {
+    unsafe {
+        assert!(TestIgnoreNonSerializableNonZeroSized::repr_c_optimization_safe(0).is_false());
+    }
+    assert_roundtrip(TestIgnoreNonSerializableNonZeroSized {
+        a: 42.0,
+        b: 43.0,
+        cached_product: NonSerializableNonZeroSized(0),
+    });
+}
+
 #[test]
 pub fn test_indexmap() {
     let mut imap = IndexMap::new();

--- a/savefile/Cargo.toml
+++ b/savefile/Cargo.toml
@@ -62,7 +62,7 @@ bit-set08 = {package="bit-set", version = "0.8", optional = true}
 rustc-hash = {version = "2.1.0", optional = true}
 memoffset = "0.9"
 byteorder = "1.4"
-savefile-derive = {path="../savefile-derive", version = "=0.20.1", optional = true }
+savefile-derive = {path="../savefile-derive", version = "=0.20.2", optional = true }
 serde_derive = {version= "1.0", optional = true}
 serde = {version= "1.0", optional = true}
 quickcheck = {version= "1.0", optional = true}
@@ -70,7 +70,7 @@ emath = {version = "0.30", optional = true}
 ecolor = {version = "0.30", optional = true}
 
 [dev-dependencies]
-savefile-derive = { path="../savefile-derive", version = "=0.20.1" }
+savefile-derive = { path="../savefile-derive", version = "=0.20.2" }
 
 [build-dependencies]
 rustc_version="0.4"


### PR DESCRIPTION
Fix bug where `#[savefile_ignore]` didn't work if the ignored field was first or last,
and its datatype did not implement the `Packed` trait.